### PR TITLE
Also specify required AppIndicator3 version

### DIFF
--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -35,6 +35,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GLib, GObject
 
 try:
+    gi.require_version('AppIndicator3', '0.1')
     from gi.repository import AppIndicator3 as appindicator
 except ImportError:
     appindicator = None


### PR DESCRIPTION
Avoid another GObject Introspection warning in redshift-gtk by providing
the required version of AppIndicator3 before import it.