### PR TITLE
Fallback if AppIndicator3 req. version unavailable

### DIFF
--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -37,7 +37,7 @@ from gi.repository import Gtk, GLib, GObject
 try:
     gi.require_version('AppIndicator3', '0.1')
     from gi.repository import AppIndicator3 as appindicator
-except ImportError:
+except (ImportError, ValueError):
     appindicator = None
 
 from . import defs


### PR DESCRIPTION
Catch in the except block the case when the required version of
Appindicator3 is not available to also fallback in GtkStatusIcon widget.